### PR TITLE
Upgrading retrofit version to 2.5 fixing (CVE-2018-1000850, CVE-2018-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j.api.version>2.6.1</log4j.api.version>
         <log4j.core.version>2.6.1</log4j.core.version>
-        <retrofit.version>2.3.0</retrofit.version>
+        <retrofit.version>2.5.0</retrofit.version>
         <converter.jackson.version>2.3.0</converter.jackson.version>
         <logging.interceptor.version>3.9.0</logging.interceptor.version>
         <jackson.databind.version>2.9.5</jackson.databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <retrofit.version>2.5.0</retrofit.version>
         <converter.jackson.version>2.3.0</converter.jackson.version>
         <logging.interceptor.version>3.9.0</logging.interceptor.version>
-        <jackson.databind.version>2.9.5</jackson.databind.version>
+        <jackson.databind.version>2.9.8</jackson.databind.version>
         <junit.version>4.12</junit.version>
         <mockito.all.version>1.10.19</mockito.all.version>
     </properties>


### PR DESCRIPTION
Security potential issues:
Upgrade com.squareup.retrofit2 to version 2.5.0 or later.
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.8.