### PR TITLE
Add verification pixel support

### DIFF
--- a/src/main/java/com/taboola/backstage/model/media/campaigns/Campaign.java
+++ b/src/main/java/com/taboola/backstage/model/media/campaigns/Campaign.java
@@ -59,6 +59,7 @@ public class Campaign {
     @ReadOnly
     protected CampaignStatus status;
     protected Double cpaGoal;
+    protected VerificationPixel verificationPixel;
 
     public String getId() {
         return id;
@@ -180,6 +181,9 @@ public class Campaign {
         return cpaGoal;
     }
 
+    public VerificationPixel getVerificationPixel() {
+        return verificationPixel;
+    }
     @Override
     public String toString() {
         return "Campaign{" +
@@ -213,6 +217,7 @@ public class Campaign {
                 ", spent=" + spent +
                 ", status=" + status +
                 ", cpaGoal=" + cpaGoal +
+                ", verificationPixel=" + verificationPixel +
                 '}';
     }
 
@@ -250,6 +255,7 @@ public class Campaign {
                 Objects.equals(isActive, campaign.isActive) &&
                 Objects.equals(spent, campaign.spent) &&
                 status == campaign.status &&
+                Objects.equals(verificationPixel, campaign.verificationPixel) &&
                 Objects.equals(cpaGoal, campaign.cpaGoal);
     }
 
@@ -258,6 +264,6 @@ public class Campaign {
         return Objects.hash(id, advertiserId, name, brandingText, trackingCode, cpc, dailyCap, dailyAdDeliveryModel, publisherBidModifier,
                 trafficAllocationMode, spendingLimit, spendingLimitModel, countryTargeting, subCountryTargeting, platformTargeting, publisherTargeting,
                 osTargeting, connectionTypeTargeting, postalCodeTargeting, comments, bidType, marketingObjective,
-                activitySchedule, startDate, endDate, approvalState, isActive, spent, status, cpaGoal);
+                activitySchedule, startDate, endDate, approvalState, isActive, spent, status, cpaGoal, verificationPixel);
     }
 }

--- a/src/main/java/com/taboola/backstage/model/media/campaigns/CampaignOperation.java
+++ b/src/main/java/com/taboola/backstage/model/media/campaigns/CampaignOperation.java
@@ -137,4 +137,9 @@ public class CampaignOperation extends Campaign {
         this.cpaGoal = cpaGoal;
         return this;
     }
+
+    public CampaignOperation setVerificationPixel(VerificationPixel verificationPixel) {
+        this.verificationPixel = verificationPixel;
+        return this;
+    }
 }

--- a/src/main/java/com/taboola/backstage/model/media/campaigns/VerificationPixel.java
+++ b/src/main/java/com/taboola/backstage/model/media/campaigns/VerificationPixel.java
@@ -1,0 +1,43 @@
+package com.taboola.backstage.model.media.campaigns;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Created by George
+ * Date: 5/2/2020
+ * Time: 17:00 PM
+ * By InPowered
+ */
+public class VerificationPixel {
+    private List<VerificationPixelItem> verificationPixelItems;
+
+    public List<VerificationPixelItem> getVerificationPixelItems() {
+        return verificationPixelItems;
+    }
+
+    public void setVerificationPixelItems(List<VerificationPixelItem> verificationPixelItems) {
+        this.verificationPixelItems = verificationPixelItems;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("VerificationPixel{");
+        sb.append("verificationPixelItems=").append(verificationPixelItems);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VerificationPixel)) return false;
+        VerificationPixel that = (VerificationPixel) o;
+        return Objects.equals(getVerificationPixelItems(), that.getVerificationPixelItems());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVerificationPixelItems());
+    }
+}

--- a/src/main/java/com/taboola/backstage/model/media/campaigns/VerificationPixelItem.java
+++ b/src/main/java/com/taboola/backstage/model/media/campaigns/VerificationPixelItem.java
@@ -1,0 +1,53 @@
+package com.taboola.backstage.model.media.campaigns;
+
+import java.util.Objects;
+
+/**
+ * Created by George
+ * Date: 5/2/2020
+ * Time: 17:00 PM
+ * By InPowered
+ */
+public class VerificationPixelItem {
+    private VerificationPixelType verificationPixelType;
+    private String url;
+
+    public VerificationPixelType getVerificationPixelType() {
+        return verificationPixelType;
+    }
+
+    public void setVerificationPixelType(VerificationPixelType verificationPixelType) {
+        this.verificationPixelType = verificationPixelType;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("VerificationPixelItem{");
+        sb.append("verificationPixelType=").append(verificationPixelType);
+        sb.append(", url='").append(url).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VerificationPixelItem)) return false;
+        VerificationPixelItem that = (VerificationPixelItem) o;
+        return getVerificationPixelType() == that.getVerificationPixelType() &&
+                Objects.equals(getUrl(), that.getUrl());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVerificationPixelType(), getUrl());
+    }
+}

--- a/src/main/java/com/taboola/backstage/model/media/campaigns/VerificationPixelType.java
+++ b/src/main/java/com/taboola/backstage/model/media/campaigns/VerificationPixelType.java
@@ -1,0 +1,13 @@
+package com.taboola.backstage.model.media.campaigns;
+
+/**
+ * Created by George
+ * Date: 5/2/2020
+ * Time: 17:00 PM
+ * By InPowered
+ */
+public enum VerificationPixelType {
+    CLICK,
+    IMPRESSION,
+    VIEWABLE_IMPRESSION
+}


### PR DESCRIPTION
Add verification pixel support

Taboola Ads Manager added 3rd Party Pixel support, [campaigns-overview](https://developers.taboola.com/backstage-api/reference#campaigns-overview)